### PR TITLE
fix travis config warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: xenial
+dist: focal
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+os: linux
 dist: xenial
 
 services:
@@ -19,4 +20,4 @@ deploy:
     user: shogo82148
     key: '$BINTRAY_API_KEY'
     file: ./bintray/bintray-fluent-bit.json
-    skip_cleanup: true
+    cleanup: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,5 @@ deploy:
     key: '$BINTRAY_API_KEY'
     file: ./bintray/bintray-fluent-bit.json
     cleanup: false
+    on:
+      branch: main


### PR DESCRIPTION
deploy: deprecated key skip_cleanup (not supported in dpl v2, use cleanup)
root: missing os, using the default linux