### PR TITLE
enable in-http plugin

### DIFF
--- a/Dockerfile.almalinux8
+++ b/Dockerfile.almalinux8
@@ -25,7 +25,7 @@ RUN cat ../CMakeLists.txt | \
     perl -pe "s/\\bset\\(CPACK_PACKAGING_INSTALL_PREFIX\\s+.*\\)\$/set(CPACK_PACKAGING_INSTALL_PREFIX \"\\/\")/g" \
     > /tmp/CMakeLists.txt && mv /tmp/CMakeLists.txt ..
 
-RUN cmake3 -DFLB_IN_HTTP=Off ..
+RUN cmake3 ..
 RUN make -j$(nproc)
 RUN cpack3 -G RPM
 CMD cp *.rpm /output/

--- a/Dockerfile.amazonlinux2
+++ b/Dockerfile.amazonlinux2
@@ -24,7 +24,7 @@ RUN cat ../CMakeLists.txt | \
     perl -pe "s/\\bset\\(CPACK_PACKAGING_INSTALL_PREFIX\\s+.*\\)\$/set(CPACK_PACKAGING_INSTALL_PREFIX \"\\/\")/g" \
     > /tmp/CMakeLists.txt && mv /tmp/CMakeLists.txt ..
 
-RUN cmake3 -DFLB_IN_HTTP=Off ..
+RUN cmake3 ..
 RUN make -j$(nproc)
 RUN cpack3 -G RPM
 CMD cp *.rpm /output/

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -25,7 +25,7 @@ RUN cat ../CMakeLists.txt | \
     perl -pe "s/\\bset\\(CPACK_PACKAGING_INSTALL_PREFIX\\s+.*\\)\$/set(CPACK_PACKAGING_INSTALL_PREFIX \"\\/\")/g" \
     > /tmp/CMakeLists.txt && mv /tmp/CMakeLists.txt ..
 
-RUN cmake3 -DFLB_IN_HTTP=Off ..
+RUN cmake3 ..
 RUN make -j$(nproc)
 RUN cpack3 -G RPM
 CMD cp *.rpm /output/

--- a/Dockerfile.centos8
+++ b/Dockerfile.centos8
@@ -25,7 +25,7 @@ RUN cat ../CMakeLists.txt | \
     perl -pe "s/\\bset\\(CPACK_PACKAGING_INSTALL_PREFIX\\s+.*\\)\$/set(CPACK_PACKAGING_INSTALL_PREFIX \"\\/\")/g" \
     > /tmp/CMakeLists.txt && mv /tmp/CMakeLists.txt ..
 
-RUN cmake3 -DFLB_IN_HTTP=Off ..
+RUN cmake3 ..
 RUN make -j$(nproc)
 RUN cpack3 -G RPM
 CMD cp *.rpm /output/


### PR DESCRIPTION
in-http plugin was disable due to a workaround of https://github.com/fluent/fluent-bit/issues/2930
but no longer need it