### PR TITLE
introduce rocky linux 8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,14 @@ jobs:
           - centos7
           - centos8
           - almalinux8
+          - rockylinux8
         platform:
           - linux/amd64
           - linux/arm64
+        exclude:
+          # RockyLinux doesn't provide arm64 image now (2021-06-06)
+          - distribution: rockylinux8
+            platform: linux/arm64
 
     steps:
       - uses: docker/setup-qemu-action@v1

--- a/Dockerfile.rockylinux8
+++ b/Dockerfile.rockylinux8
@@ -1,0 +1,31 @@
+FROM rockylinux/rockylinux:8.4-rc1
+ENV HOME /
+RUN dnf update -y
+RUN dnf install -y epel-release
+RUN dnf install -y rpm-build make gcc-c++ tar gzip cmake pkgconfig systemd-devel cyrus-sasl-devel zlib-devel flex bison unzip openssl-devel libgcrypt-devel perl
+
+ARG FLB_PREFIX
+ARG FLB_VERSION
+ARG FLB_RELEASE
+
+ENV FLB_TARBALL http://github.com/fluent/fluent-bit/archive/$FLB_PREFIX$FLB_VERSION.zip
+
+RUN cd /tmp && \
+    curl -sSL -o "/tmp/fluent-bit-${FLB_VERSION}.zip" ${FLB_TARBALL} && \
+    unzip "fluent-bit-$FLB_VERSION.zip"
+WORKDIR "/tmp/fluent-bit-${FLB_VERSION}/build"
+
+# override package information
+# because it is not the official package td-agent.
+RUN cat ../CMakeLists.txt | \
+    perl -pe "s/\\bset\\(CPACK_PACKAGE_NAME\\s+.*\\)\$/set(CPACK_PACKAGE_NAME \"fluent-bit\")/g" | \
+    perl -pe "s/\\bset\\(CPACK_PACKAGE_RELEASE\\s+.*\\)\$/set(CPACK_PACKAGE_RELEASE \"$FLB_RELEASE.el8\")/g" | \
+    perl -pe "s/\\bset\\(CPACK_PACKAGE_CONTACT\\s+.*\\)\$/set(CPACK_PACKAGE_CONTACT \"Ichinose Shogo <shogo82148@gmail.com>\")/g" | \
+    perl -pe "s/\\bset\\(CPACK_PACKAGE_VENDOR\\s+.*\\)\$/set(CPACK_PACKAGE_VENDOR \"Ichinose Shogo\")/g" | \
+    perl -pe "s/\\bset\\(CPACK_PACKAGING_INSTALL_PREFIX\\s+.*\\)\$/set(CPACK_PACKAGING_INSTALL_PREFIX \"\\/\")/g" \
+    > /tmp/CMakeLists.txt && mv /tmp/CMakeLists.txt ..
+
+RUN cmake ..
+RUN make -j$(nproc)
+RUN cpack -G RPM
+CMD cp *.rpm /output/

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 FLB_VERSION := 1.7.8
 FLB_RELEASE := 1
 
-.PHONY: all clean amazonlinux2 centos7 centos8 upload almalinux8
+.PHONY: all clean amazonlinux2 centos7 centos8 upload almalinux8 rockylinux8
 
-all: amazonlinux2 centos7 centos8 almalinux8
+all: amazonlinux2 centos7 centos8 almalinux8 rockylinux8
 amazonlinux2:
 	scripts/build.bash $(FLB_VERSION) $(FLB_RELEASE) amazonlinux2
 
@@ -15,6 +15,9 @@ centos8:
 
 almalinux8:
 	scripts/build.bash $(FLB_VERSION) $(FLB_RELEASE) almalinux8
+
+rockylinux8:
+	scripts/build.bash $(FLB_VERSION) $(FLB_RELEASE) rockylinux8
 
 upload:
 	scripts/upload.pl


### PR DESCRIPTION
The status of Rocky Linux is still RC1
https://rockylinux.org/ja/news/rocky-linux-8-4-rc1-release/

However, it looks that the docker image is available on DockerHub.
https://wiki.rockylinux.org/en/link-directory
https://hub.docker.com/r/rockylinux/rockylinux