### PR TITLE
build: fix rpm user file list

### DIFF
--- a/Dockerfile.almalinux8
+++ b/Dockerfile.almalinux8
@@ -1,5 +1,5 @@
 FROM almalinux:8
-ENV HOME /
+
 RUN dnf update -y
 RUN dnf install -y epel-release
 RUN dnf install -y rpm-build make gcc-c++ tar gzip cmake pkgconfig systemd-devel cyrus-sasl-devel zlib-devel flex bison unzip openssl-devel libgcrypt-devel perl
@@ -14,6 +14,10 @@ RUN cd /tmp && \
     curl -sSL -o "/tmp/fluent-bit-${FLB_VERSION}.zip" ${FLB_TARBALL} && \
     unzip "fluent-bit-$FLB_VERSION.zip"
 WORKDIR "/tmp/fluent-bit-${FLB_VERSION}/build"
+
+# apply patches
+COPY patches /patches
+RUN cd .. && cat /patches/*.patch | patch -p1
 
 # override package information
 # because it is not the official package td-agent.

--- a/Dockerfile.amazonlinux2
+++ b/Dockerfile.amazonlinux2
@@ -1,5 +1,5 @@
 FROM amazonlinux:2
-ENV HOME /
+
 RUN yum update -y
 RUN yum install -y rpm-build make gcc-c++ tar gzip cmake3 pkgconfig systemd-devel cyrus-sasl-devel zlib-devel flex bison unzip
 
@@ -13,6 +13,10 @@ RUN cd /tmp && \
     curl -sSL -o "/tmp/fluent-bit-${FLB_VERSION}.zip" ${FLB_TARBALL} && \
     unzip "fluent-bit-$FLB_VERSION.zip"
 WORKDIR "/tmp/fluent-bit-${FLB_VERSION}/build"
+
+# apply patches
+COPY patches /patches
+RUN cd .. && cat /patches/*.patch | patch -p1
 
 # override package information
 # because it is not the official package td-agent.

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -1,5 +1,5 @@
 FROM centos:7
-ENV HOME /
+
 RUN yum update -y
 RUN yum install -y epel-release
 RUN yum install -y rpm-build make gcc-c++ tar gzip cmake3 pkgconfig systemd-devel cyrus-sasl-devel zlib-devel flex bison unzip openssl-devel libgcrypt-devel
@@ -14,6 +14,10 @@ RUN cd /tmp && \
     curl -sSL -o "/tmp/fluent-bit-${FLB_VERSION}.zip" ${FLB_TARBALL} && \
     unzip "fluent-bit-$FLB_VERSION.zip"
 WORKDIR "/tmp/fluent-bit-${FLB_VERSION}/build"
+
+# apply patches
+COPY patches /patches
+RUN cd .. && cat /patches/*.patch | patch -p1
 
 # override package information
 # because it is not the official package td-agent.

--- a/Dockerfile.centos8
+++ b/Dockerfile.centos8
@@ -1,5 +1,5 @@
 FROM centos:8
-ENV HOME /
+
 RUN dnf update -y
 RUN dnf install -y epel-release
 RUN dnf install -y rpm-build make gcc-c++ tar gzip cmake pkgconfig systemd-devel cyrus-sasl-devel zlib-devel flex bison unzip openssl-devel libgcrypt-devel perl
@@ -14,6 +14,10 @@ RUN cd /tmp && \
     curl -sSL -o "/tmp/fluent-bit-${FLB_VERSION}.zip" ${FLB_TARBALL} && \
     unzip "fluent-bit-$FLB_VERSION.zip"
 WORKDIR "/tmp/fluent-bit-${FLB_VERSION}/build"
+
+# apply patches
+COPY patches /patches
+RUN cd .. && cat /patches/*.patch | patch -p1
 
 # override package information
 # because it is not the official package td-agent.

--- a/Dockerfile.rockylinux8
+++ b/Dockerfile.rockylinux8
@@ -1,5 +1,5 @@
 FROM rockylinux/rockylinux:8
-ENV HOME /
+
 RUN dnf update -y
 RUN dnf install -y epel-release
 RUN dnf install -y rpm-build make gcc-c++ tar gzip cmake pkgconfig systemd-devel cyrus-sasl-devel zlib-devel flex bison unzip openssl-devel libgcrypt-devel perl
@@ -14,6 +14,10 @@ RUN cd /tmp && \
     curl -sSL -o "/tmp/fluent-bit-${FLB_VERSION}.zip" ${FLB_TARBALL} && \
     unzip "fluent-bit-$FLB_VERSION.zip"
 WORKDIR "/tmp/fluent-bit-${FLB_VERSION}/build"
+
+# apply patches
+COPY patches /patches
+RUN cd .. && cat /patches/*.patch | patch -p1
 
 # override package information
 # because it is not the official package td-agent.

--- a/patches/pull-3755-fix-rpm-user-file-list.patch
+++ b/patches/pull-3755-fix-rpm-user-file-list.patch
@@ -1,0 +1,36 @@
+From 16c71d6a58daa6675934e95c3f0fc71eea62bc7f Mon Sep 17 00:00:00 2001
+From: Jorge Niedbalski <j@calyptia.com>
+Date: Fri, 9 Jul 2021 12:36:43 -0400
+Subject: [PATCH] build: fix rpm user file list.
+
+the global user file list doesn't work
+with some versions of cpack and has to be explicit
+to the component that is building (runtime).
+
+Signed-off-by: Jorge Niedbalski <j@calyptia.com>
+---
+ CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ab961677e..5f552206e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -781,7 +781,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+   set(FLB_INSTALL_INCLUDEDIR "include")
+ else()
+   set(FLB_INSTALL_BINDIR ${CMAKE_INSTALL_FULL_BINDIR})
+-  set(FLB_INSTALL_LIBDIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
++  set(FLB_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}/${FLB_OUT_NAME}")
+   set(FLB_INSTALL_CONFDIR "${CMAKE_INSTALL_SYSCONFDIR}/${FLB_OUT_NAME}/")
+   set(FLB_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_PREFIX}/include")
+ endif()
+@@ -884,7 +884,7 @@ set(CPACK_RPM_PACKAGE_RELEASE ${CPACK_PACKAGE_RELEASE})
+ set(CPACK_PACKAGE_DESCRIPTION_FILE "${PROJECT_SOURCE_DIR}/cpack/description")
+ set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Fast data collector for Linux")
+ set(CPACK_RPM_SPEC_MORE_DEFINE "%define ignore \#")
+-set(CPACK_RPM_USER_FILELIST
++set(CPACK_RPM_RUNTIME_USER_FILELIST
+   "%config(noreplace) /etc/${FLB_OUT_NAME}/${FLB_OUT_NAME}.conf"
+   "%config(noreplace) /etc/${FLB_OUT_NAME}/parsers.conf"
+   "%config(noreplace) /etc/${FLB_OUT_NAME}/plugins.conf"

--- a/scripts/build.bash
+++ b/scripts/build.bash
@@ -25,7 +25,7 @@ docker buildx build \
     --build-arg FLB_PREFIX=v \
     --build-arg FLB_RELEASE="$FLB_RELEASE" \
     -t "flb-$FLB_DISTRO-$FLB_VERSION" \
-    -f "$ROOT/Dockerfile.$FLB_DISTRO" "$ROOT/$FLB_DISTRO.build"
+    -f "$ROOT/Dockerfile.$FLB_DISTRO" "$ROOT"
 
 docker run \
     --rm \


### PR DESCRIPTION
fix the following error while `yum install`.

> Transaction couldn't start:
file /lib from install of fluent-bit-1.8.1-1.amzn2.x86_64 conflicts with file from package filesystem-3.2-25.amzn2.0.4.x86_64

the patch comes from https://github.com/fluent/fluent-bit/pull/3755